### PR TITLE
Mark `mirage-msw` as a module type package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mirage-msw",
   "version": "0.1.1",
+  "type": "module",
   "description": "Allow mirage to use MSW (Mock Service Worker) as the interceptor",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
Add `"type": "module"` to the package.json to indicate to bundlers like vite that the package should be interpreted as ES modules, rather than CommonJS